### PR TITLE
update parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.verapdf</groupId>
     <artifactId>verapdf-parent</artifactId>
-    <version>1.0.17</version>
+    <version>1.12.2</version>
   </parent>
 
   <groupId>org.verapdf</groupId>


### PR DESCRIPTION
otherwise it wont build with sth like 
```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.verapdf:verapdf-rest:0.1.0-SNAPSHOT: Could not find artifact org.verapdf:verapdf-parent:pom:1.0.17 in vera-pdfbox (http://artifactory.opf-labs.org/artifactory/vera-pdfbox-local) and 'parent.relativePath' points at wrong local POM @ line 6, column 11
 @
[ERROR] The build could not read 1 project -> [Help 1]
```