### PR TITLE
FIX: Docker HTTPS/SSL URL downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ FROM eclipse-temurin:11 as jre-builder
 
 # Create a custom Java runtime
 RUN "$JAVA_HOME/bin/jlink" \
-         --add-modules java.base,java.logging,java.xml,java.management,java.sql,java.desktop \
+         --add-modules java.base,java.logging,java.xml,java.management,java.sql,java.desktop,jdk.crypto.ec \
          --strip-debug \
          --no-man-pages \
          --no-header-files \

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -37,10 +37,6 @@ ENV JAVA_OPTS=$JAVA_OPTS
 ARG VERAPDF_REST_VERSION
 ENV VERAPDF_REST_VERSION=${VERAPDF_REST_VERSION:-0.2.0-SNAPSHOT}
 
-# RUN apt-get update && apt-get install -y --no-install-recommends \
-#     ssl-cert \
-#     ca-certificates-java \
-#     && rm -rf /var/lib/apt/lists/*
 COPY --from=dev-builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -20,7 +20,7 @@ FROM eclipse-temurin:11 as jre-builder
 
 # Create a custom Java runtime
 RUN "$JAVA_HOME/bin/jlink" \
-         --add-modules java.base,java.logging,java.xml,java.management,java.sql,java.desktop \
+         --add-modules java.base,java.logging,java.xml,java.management,java.sql,java.desktop,jdk.crypto.ec \
          --strip-debug \
          --no-man-pages \
          --no-header-files \
@@ -37,6 +37,10 @@ ENV JAVA_OPTS=$JAVA_OPTS
 ARG VERAPDF_REST_VERSION
 ENV VERAPDF_REST_VERSION=${VERAPDF_REST_VERSION:-0.2.0-SNAPSHOT}
 
+# RUN apt-get update && apt-get install -y --no-install-recommends \
+#     ssl-cert \
+#     ca-certificates-java \
+#     && rm -rf /var/lib/apt/lists/*
 COPY --from=dev-builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
 RUN chmod +x /usr/local/bin/dumb-init
 


### PR DESCRIPTION
- added `jdk.crypto.ec` to the custom JRE build in both Dockerfiles.

Fixes issue with HTTPS URL downloads when deployed as a container.