### PR TITLE
FEAT: Slimmer Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 # First build the app on a maven open jdk 11 container
-FROM maven:3.8.6-openjdk-11 as app-builder
+FROM maven:3-eclipse-temurin-11-alpine AS app-builder
+RUN apk add --no-cache git
 WORKDIR /build
 
 # A specifc git branch, tag or commit to build from, defaults to master (release build)
@@ -13,13 +14,9 @@ RUN git clone https://github.com/veraPDF/veraPDF-rest.git
 WORKDIR /build/veraPDF-rest
 RUN git checkout ${GH_CHECKOUT} && mvn clean package
 
-# Install dumb-init for process safety
-# https://github.com/Yelp/dumb-init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
-
 # Now build a Java JRE for the Alpine application image
 # https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
-FROM eclipse-temurin:11 as jre-builder
+FROM eclipse-temurin:11-jdk-alpine as jre-builder
 
 # Create a custom Java runtime
 RUN "$JAVA_HOME/bin/jlink" \
@@ -31,16 +28,14 @@ RUN "$JAVA_HOME/bin/jlink" \
          --output /javaruntime
 
 # Now the final application image
-FROM debian:bullseye-slim
+FROM alpine:3
 
-# Set for additional arguments passed to the java run command, no default
-ARG JAVA_OPTS
-ENV JAVA_OPTS=$JAVA_OPTS
 # Specify the veraPDF REST version if you want to (to be used in build automation), default is 1.27.1
 ARG VERAPDF_REST_VERSION
 ENV VERAPDF_REST_VERSION=${VERAPDF_REST_VERSION:-1.27.1}
 
-COPY --from=app-builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
+# Set up dumb-init for process safety: https://github.com/Yelp/dumb-init
+ADD --link https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init 
 RUN chmod +x /usr/local/bin/dumb-init
 
 # Copy the JRE from the previous stage
@@ -50,14 +45,14 @@ COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 # Since this is a running network service we'll create an unprivileged account
 # which will be used to perform the rest of the work and run the actual service:
-RUN useradd --system --user-group --home-dir=/opt/verapdf-rest verapdf-rest
+RUN addgroup -S verapdf-rest && adduser --system -D --home /opt/verapdf-rest -G verapdf-rest verapdf-rest
 RUN mkdir --parents /var/opt/verapdf-rest/logs && chown -R verapdf-rest:verapdf-rest /var/opt/verapdf-rest
 
 USER verapdf-rest
 WORKDIR /opt/verapdf-rest
 
 # Copy the application from the previous stage
-COPY --from=app-builder /build/veraPDF-rest/target/verapdf-rest-${VERAPDF_REST_VERSION}.jar /opt/verapdf-rest/
+COPY --from=app-builder /build/veraPDF-rest/target/verapdf-rest-${VERAPDF_REST_VERSION}.jar /opt/verapdf-rest/verapdf-rest.jar
 # Copy the default configuration file
 COPY --from=app-builder /build/veraPDF-rest/server.yml /var/opt/verapdf-rest/config/
 COPY --from=app-builder /build/veraPDF-rest/config /opt/verapdf-rest/config/
@@ -65,4 +60,5 @@ COPY --from=app-builder /build/veraPDF-rest/config /opt/verapdf-rest/config/
 VOLUME /var/opt/verapdf-rest
 EXPOSE 8080
 
-ENTRYPOINT dumb-init java $JAVA_OPTS -Djava.awt.headless=true -jar /opt/verapdf-rest/verapdf-rest-${VERAPDF_REST_VERSION}.jar server /var/opt/verapdf-rest/config/server.yml
+ENTRYPOINT [ "dumb-init", "--" ]
+CMD ["java", "-Djava.awt.headless=true", "-jar", "/opt/verapdf-rest/verapdf-rest.jar", "server", "/var/opt/verapdf-rest/config/server.yml"]

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,6 +1,6 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
 # First build the app on a maven open jdk 11 container
-FROM maven:3.8.6-openjdk-11 as dev-builder
+FROM maven:3-eclipse-temurin-11-alpine AS dev-builder
 WORKDIR /build
 
 # Copy the current dev source branch to a local build dir
@@ -10,13 +10,9 @@ COPY pom.xml /build/veraPDF-rest/
 WORKDIR /build/veraPDF-rest
 RUN mvn clean package
 
-# Install dumb-init for process safety
-# https://github.com/Yelp/dumb-init
-RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64
-
 # Now build a Java JRE for the Alpine application image
 # https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
-FROM eclipse-temurin:11 as jre-builder
+FROM eclipse-temurin:11-jdk-alpine as jre-builder
 
 # Create a custom Java runtime
 RUN "$JAVA_HOME/bin/jlink" \
@@ -28,16 +24,14 @@ RUN "$JAVA_HOME/bin/jlink" \
          --output /javaruntime
 
 # Now the final application image
-FROM debian:bullseye-slim
+FROM alpine:3
 
-# Set for additional arguments passed to the java run command, no default
-ARG JAVA_OPTS
-ENV JAVA_OPTS=$JAVA_OPTS
 # Specify the veraPDF REST version if you want to (to be used in build automation), default is 1.27.1
 ARG VERAPDF_REST_VERSION
 ENV VERAPDF_REST_VERSION=${VERAPDF_REST_VERSION:-1.27.1}
 
-COPY --from=dev-builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
+# Set up dumb-init for process safety: https://github.com/Yelp/dumb-init
+ADD --link https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 /usr/local/bin/dumb-init 
 RUN chmod +x /usr/local/bin/dumb-init
 
 # Copy the JRE from the previous stage
@@ -47,14 +41,14 @@ COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 # Since this is a running network service we'll create an unprivileged account
 # which will be used to perform the rest of the work and run the actual service:
-RUN useradd --system --user-group --home-dir=/opt/verapdf-rest verapdf-rest
+RUN addgroup -S verapdf-rest && adduser --system -D --home /opt/verapdf-rest -G verapdf-rest verapdf-rest
 RUN mkdir --parents /var/opt/verapdf-rest/logs && chown -R verapdf-rest:verapdf-rest /var/opt/verapdf-rest
 
 USER verapdf-rest
-
 WORKDIR /opt/verapdf-rest
 # Copy the application from the previous stage
-COPY --from=dev-builder /build/veraPDF-rest/target/verapdf-rest-${VERAPDF_REST_VERSION}.jar /opt/verapdf-rest/
+COPY --from=dev-builder /build/veraPDF-rest/target/verapdf-rest-${VERAPDF_REST_VERSION}.jar /opt/verapdf-rest/verapdf-rest.jar
+
 # Copy the default configuration file
 COPY server.yml /var/opt/verapdf-rest/config/
 COPY config /opt/verapdf-rest/config/
@@ -62,4 +56,5 @@ COPY config /opt/verapdf-rest/config/
 VOLUME /var/opt/verapdf-rest
 EXPOSE 8080
 
-ENTRYPOINT dumb-init java $JAVA_OPTS -Djava.awt.headless=true -jar /opt/verapdf-rest/verapdf-rest-${VERAPDF_REST_VERSION}.jar server /var/opt/verapdf-rest/config/server.yml
+ENTRYPOINT [ "dumb-init", "--" ]
+CMD ["java", "-Djava.awt.headless=true", "-jar", "/opt/verapdf-rest/verapdf-rest.jar", "server", "/var/opt/verapdf-rest/config/server.yml"]


### PR DESCRIPTION
- using `alpine:3` for final image for smaller image size;
- REMOVED `JAVA_OPTS` argument as args don't play nicely with `CMD` in Dockerfile;
- using Alpine Linux explicity for `app-builder` stage;
- using preferred `ENTRYPOINT` and `CMD` form for `dumb-init`;
- removed version from execution and use a vanilla name in copy instead; and
- use ADD to directly install `dumb-init` in the final image.

For reference, these changes substantially slim down the docker image again. See the difference between the `alpine` tag and `latest` below.

```shell
REPOSITORY                      TAG            IMAGE ID       CREATED         SIZE
verapdf/rest                    alpine         28609b40e825   2 minutes ago   95.9MB
verapdf/rest                    latest         8457b9b76994   3 months ago    171MB
ghcr.io/mealie-recipes/mealie   v1.0.0-RC1.1   5d9b72b27fad   11 months ago   1.19GB
```