### PR TITLE
Migrate to Dropwizard 5 / Jetty 12 and the jakarta namespace

### DIFF
--- a/.github/workflows/push-github.yml
+++ b/.github/workflows/push-github.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 17
 
       - name: Run rest-api-tests-with-docker-image
         uses: actions/github-script@v6

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [11, 17, 21, 25]
+        java-version: [17, 21, 25]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/update-arlington-workflow.yml
+++ b/.github/workflows/update-arlington-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [11, 17, 21, 25]
+        java-version: [17, 21, 25]
 
     steps:
       - name: Checkout code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-# First build the app on a maven open jdk 11 container
-FROM maven:3-eclipse-temurin-11-alpine AS app-builder
+# First build the app on a maven open jdk 21 container
+FROM maven:3-eclipse-temurin-21-alpine AS app-builder
 RUN apk add --no-cache git
 WORKDIR /build
 
@@ -16,15 +16,19 @@ RUN git checkout ${GH_CHECKOUT} && mvn clean package
 
 # Now build a Java JRE for the Alpine application image
 # https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
-FROM eclipse-temurin:11-jdk-alpine as jre-builder
+FROM eclipse-temurin:21-jdk-alpine as jre-builder
 
-# Create a custom Java runtime
+# Create a custom Java runtime.
+#
+# jdk.unsupported carries sun.misc.Unsafe, which the Swagger classpath
+# scanner reaches for on the first /openapi.json request. Without it that
+# request answers 500 and every request after it answers 200.
 RUN "$JAVA_HOME/bin/jlink" \
-         --add-modules java.base,java.compiler,java.logging,java.xml,java.management,java.sql,java.desktop,jdk.crypto.ec \
+         --add-modules java.base,java.compiler,java.logging,java.xml,java.management,java.sql,java.desktop,jdk.crypto.ec,jdk.unsupported \
          --strip-debug \
          --no-man-pages \
          --no-header-files \
-         --compress=2 \
+         --compress=zip-6 \
          --output /javaruntime
 
 # Now the final application image

--- a/Dockerfile_dev
+++ b/Dockerfile_dev
@@ -1,6 +1,6 @@
 # See https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-# First build the app on a maven open jdk 11 container
-FROM maven:3-eclipse-temurin-11-alpine AS dev-builder
+# First build the app on a maven open jdk 21 container
+FROM maven:3-eclipse-temurin-21-alpine AS dev-builder
 WORKDIR /build
 
 # Copy the current dev source branch to a local build dir
@@ -12,15 +12,19 @@ RUN mvn clean package
 
 # Now build a Java JRE for the Alpine application image
 # https://github.com/docker-library/docs/blob/master/eclipse-temurin/README.md#creating-a-jre-using-jlink
-FROM eclipse-temurin:11-jdk-alpine as jre-builder
+FROM eclipse-temurin:21-jdk-alpine as jre-builder
 
-# Create a custom Java runtime
+# Create a custom Java runtime.
+#
+# jdk.unsupported carries sun.misc.Unsafe, which the Swagger classpath
+# scanner reaches for on the first /openapi.json request. Without it that
+# request answers 500 and every request after it answers 200.
 RUN "$JAVA_HOME/bin/jlink" \
-         --add-modules java.base,java.compiler,java.logging,java.xml,java.management,java.sql,java.desktop,jdk.crypto.ec \
+         --add-modules java.base,java.compiler,java.logging,java.xml,java.management,java.sql,java.desktop,jdk.crypto.ec,jdk.unsupported \
          --strip-debug \
          --no-man-pages \
          --no-header-files \
-         --compress=2 \
+         --compress=zip-6 \
          --output /javaruntime
 
 # Now the final application image

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,47 @@
   </repositories>
 
   <properties>
-    <dropwizard.version>3.0.16</dropwizard.version>
+    <dropwizard.version>5.0.2</dropwizard.version>
+    <!-- Dropwizard 5.0.2 brings Jetty 12.1.9; 12.1.10 is the first release
+         with a fix for CVE-2026-10050, so the BOMs are imported explicitly. -->
+    <jetty.version>12.1.12</jetty.version>
+    <swagger.version>2.2.54</swagger.version>
+    <swagger.ui.version>5.32.14</swagger.ui.version>
+    <maven.compiler.release>17</maven.compiler.release>
     <fasterxml.version>2.21.4</fasterxml.version>
     <verapdf.validation.version>[1.31.0,1.32.0-RC)</verapdf.validation.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- These imports have to live in the root POM. Dropwizard's own BOM
+           manages Jackson and Jetty for itself, and a version a dependency
+           manages for itself wins over a plain <version> but loses to a root
+           <dependencyManagement> entry, so setting fasterxml.version alone
+           does not move the transitive jackson-databind. -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${fasterxml.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>
@@ -115,8 +152,8 @@
       <version>${dropwizard.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.jaxrs</groupId>
-      <artifactId>jackson-jaxrs-xml-provider</artifactId>
+      <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
+      <artifactId>jackson-jakarta-rs-xml-provider</artifactId>
       <version>${fasterxml.version}</version>
       <scope>compile</scope>
     </dependency>
@@ -146,10 +183,26 @@
       <artifactId>dropwizard-assets</artifactId>
       <version>${dropwizard.version}</version>
     </dependency>
+    <!-- com.smoketurner:dropwizard-swagger is not usable here any more: it
+         stops at 4.0.5-1 (released 2024-01-01) with no jakarta or Dropwizard 5
+         build. The spec is now served by registering swagger-jaxrs2's
+         OpenApiResource directly, and the UI from the swagger-ui webjar. -->
     <dependency>
-      <groupId>com.smoketurner</groupId>
-      <artifactId>dropwizard-swagger</artifactId>
-      <version>3.0.0-1</version>
+      <groupId>io.swagger.core.v3</groupId>
+      <artifactId>swagger-jaxrs2-jakarta</artifactId>
+      <version>${swagger.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>swagger-ui</artifactId>
+      <version>${swagger.ui.version}</version>
+    </dependency>
+
+    <!-- Dropwizard 5 pulls jetty-ee10-servlet but not jetty-ee10-servlets,
+         which is where CrossOriginFilter lives. -->
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlets</artifactId>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/verapdf/rest/app/VeraPdfRestApplication.java
+++ b/src/main/java/org/verapdf/rest/app/VeraPdfRestApplication.java
@@ -5,16 +5,15 @@ package org.verapdf.rest.app;
 
 import java.util.EnumSet;
 
-import javax.servlet.DispatcherType;
-import javax.servlet.FilterRegistration;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterRegistration;
 
-import io.federecio.dropwizard.swagger.SwaggerBundle;
-import io.federecio.dropwizard.swagger.SwaggerBundleConfiguration;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
-import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.eclipse.jetty.ee10.servlets.CrossOriginFilter;
 import org.verapdf.rest.resources.ApiResource;
 import org.verapdf.rest.resources.HomePageResource;
+import org.verapdf.rest.resources.SwaggerUiResource;
 import org.verapdf.rest.resources.ValidateResource;
 import org.verapdf.rest.resources.ValidationExceptionMapper;
 
@@ -24,6 +23,9 @@ import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.core.setup.Bootstrap;
 import io.dropwizard.core.setup.Environment;
 import io.dropwizard.views.common.ViewBundle;
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
+
+import java.util.Collections;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>
@@ -32,6 +34,13 @@ import io.dropwizard.views.common.ViewBundle;
 public class VeraPdfRestApplication extends Application<VeraPdfRestConfiguration> {
 
     private static final String NAME = "verapdf-rest"; //$NON-NLS-1$
+
+    /**
+     * Classpath root of the swagger-ui webjar. The version segment is part of
+     * the path, so this must be kept in step with the swagger.ui.version
+     * property in pom.xml.
+     */
+    private static final String SWAGGER_UI_WEBJAR_PATH = "/META-INF/resources/webjars/swagger-ui/5.32.14"; //$NON-NLS-1$
 
     /**
      * Main method for Jetty server application. Simply calls the run method
@@ -55,16 +64,6 @@ public class VeraPdfRestApplication extends Application<VeraPdfRestConfiguration
     public void initialize(Bootstrap<VeraPdfRestConfiguration> bootstrap) {
         bootstrap.addBundle(new MultiPartBundle());
         bootstrap.addBundle(new ViewBundle<>());
-        bootstrap.addBundle(new SwaggerBundle<VeraPdfRestConfiguration>() {
-            @Override
-            protected SwaggerBundleConfiguration getSwaggerBundleConfiguration(
-                    VeraPdfRestConfiguration configuration) {
-                SwaggerBundleConfiguration config = new SwaggerBundleConfiguration();
-                config.setResourcePackage("org.verapdf.rest.resources");
-
-                return config;
-            }
-        });
         bootstrap.setConfigurationSourceProvider(
                 new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
                                                new EnvironmentVariableSubstitutor(false)
@@ -73,6 +72,9 @@ public class VeraPdfRestApplication extends Application<VeraPdfRestConfiguration
         bootstrap.addBundle(new AssetsBundle("/assets/js", "/js", null, "js")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
         bootstrap.addBundle(new AssetsBundle("/assets/img", "/img", null, "img")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
                                                                                    // //$NON-NLS-
+        // The Swagger UI library, served from its webjar. The page that loads
+        // it is SwaggerUiResource at /swagger.
+        bootstrap.addBundle(new AssetsBundle(SWAGGER_UI_WEBJAR_PATH, "/swagger-ui", null, "swagger-ui")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Override
@@ -85,7 +87,11 @@ public class VeraPdfRestApplication extends Application<VeraPdfRestConfiguration
         environment.jersey().register(validateResource);
         environment.jersey().register(new ApiResource());
         environment.jersey().register(new HomePageResource());
+        environment.jersey().register(new SwaggerUiResource());
         environment.jersey().register(vem);
+        // Serves the OpenAPI description at /openapi.json and /openapi.yaml.
+        environment.jersey().register(new OpenApiResource()
+                .resourcePackages(Collections.singleton("org.verapdf.rest.resources"))); //$NON-NLS-1$
         // Set up cross domain REST
         setupCORS(environment);
     }

--- a/src/main/java/org/verapdf/rest/resources/ApiResource.java
+++ b/src/main/java/org/verapdf/rest/resources/ApiResource.java
@@ -17,10 +17,10 @@ import org.verapdf.ReleaseDetails;
 import org.verapdf.rest.environment.Environment;
 import org.verapdf.rest.environment.Environments;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * API wrapper resource, provides routing for child API resources.

--- a/src/main/java/org/verapdf/rest/resources/ByteStreamResource.java
+++ b/src/main/java/org/verapdf/rest/resources/ByteStreamResource.java
@@ -7,12 +7,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataParam;

--- a/src/main/java/org/verapdf/rest/resources/HomePageResource.java
+++ b/src/main/java/org/verapdf/rest/resources/HomePageResource.java
@@ -3,10 +3,10 @@ package org.verapdf.rest.resources;
 import io.swagger.v3.oas.annotations.Hidden;
 import org.verapdf.rest.views.RestClientView;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * @author <a href="mailto:carl@openpreservation.org">Carl Wilson</a>

--- a/src/main/java/org/verapdf/rest/resources/ProfileResource.java
+++ b/src/main/java/org/verapdf/rest/resources/ProfileResource.java
@@ -5,9 +5,9 @@ package org.verapdf.rest.resources;
 
 import java.util.*;
 
-import javax.inject.Singleton;
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 
 import org.verapdf.pdfa.flavours.PDFAFlavour;
 import org.verapdf.pdfa.validation.profiles.ProfileDetails;

--- a/src/main/java/org/verapdf/rest/resources/SwaggerUiResource.java
+++ b/src/main/java/org/verapdf/rest/resources/SwaggerUiResource.java
@@ -1,0 +1,29 @@
+package org.verapdf.rest.resources;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import org.verapdf.rest.views.SwaggerUiView;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+/**
+ * Serves the Swagger UI page, which reads the OpenAPI description published at
+ * /openapi.json.
+ */
+@Hidden
+@Path("/swagger")
+public class SwaggerUiResource {
+
+	/**
+	 * @return a new {@link org.verapdf.rest.views.SwaggerUiView} for the
+	 *         Swagger UI page.
+	 */
+	@GET
+	@Produces({ MediaType.TEXT_HTML })
+	public static SwaggerUiView swaggerUi() {
+		return new SwaggerUiView();
+	}
+
+}

--- a/src/main/java/org/verapdf/rest/resources/ValidateResource.java
+++ b/src/main/java/org/verapdf/rest/resources/ValidateResource.java
@@ -16,17 +16,17 @@ import java.security.NoSuchAlgorithmException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import org.apache.commons.codec.binary.Hex;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;

--- a/src/main/java/org/verapdf/rest/resources/ValidationExceptionMapper.java
+++ b/src/main/java/org/verapdf/rest/resources/ValidationExceptionMapper.java
@@ -3,10 +3,10 @@
  */
 package org.verapdf.rest.resources;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import javax.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+import jakarta.ws.rs.ext.ExceptionMapper;
 
 import org.verapdf.core.ValidationException;
 

--- a/src/main/java/org/verapdf/rest/views/SwaggerUiView.java
+++ b/src/main/java/org/verapdf/rest/views/SwaggerUiView.java
@@ -1,0 +1,22 @@
+/**
+ *
+ */
+package org.verapdf.rest.views;
+
+import io.dropwizard.views.common.View;
+
+/**
+ * Swagger UI page. The page itself is this view; the Swagger UI library it
+ * loads is served from the swagger-ui webjar, mounted at /swagger-ui by
+ * {@link org.verapdf.rest.app.VeraPdfRestApplication}.
+ */
+public class SwaggerUiView extends View {
+
+    /**
+     * Default constructor, simply calls super constructor with mustache template
+     */
+    public SwaggerUiView() {
+        super("swagger.mustache"); //$NON-NLS-1$
+    }
+
+}

--- a/src/main/resources/org/verapdf/rest/views/swagger.mustache
+++ b/src/main/resources/org/verapdf/rest/views/swagger.mustache
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>veraPDF REST API</title>
+    <link rel="stylesheet" href="/swagger-ui/swagger-ui.css">
+    <link rel="icon" type="image/png" href="/swagger-ui/favicon-32x32.png" sizes="32x32">
+  </head>
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="/swagger-ui/swagger-ui-bundle.js" charset="UTF-8"></script>
+    <script src="/swagger-ui/swagger-ui-standalone-preset.js" charset="UTF-8"></script>
+    <script>
+      window.onload = function () {
+        window.ui = SwaggerUIBundle({
+          url: "/openapi.json",
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+          plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+          layout: "StandaloneLayout"
+        });
+      };
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Moves the service to Dropwizard 5 / Jetty 12 and the `jakarta.*` namespace. Verified request-by-request against unmodified `integration` — same profiles, same validation output, same OpenAPI paths and schemas, same XML responses.

## Why

`dropwizard.version` 3.0.16 pins Jetty 10.0.26, which has five open advisories, two of them CRITICAL:

| | | fixed in |
|---|---|---|
| `CVE-2026-10050` | `jetty-security` | 12.1.10 |
| `CVE-2026-2332` | `jetty-http` | 12.1.7 |
| `CVE-2025-11143` | `jetty-http` | 12.1.5 |
| `CVE-2024-6763` | `jetty-http` | 12.0.12 |
| `CVE-2026-6790` | `jetty-server` | 12.1.9 |

A version override cannot clear these. Dropwizard 3.0.17 still pins Jetty 10.0.26 and 4.0.17 pins 11.0.26 — the same five. Jetty 10 and 11 are EOL, and the fixed 10.0.31 / 11.0.31 builds the advisories name are not published to Maven Central (`maven-metadata.xml` for `jetty-server` stops at 10.0.26 and 11.0.26). Jetty 12 is the only public fix, and Jetty 12 means Dropwizard 5 and `jakarta.*`.

## What changed

| | Before | After |
|---|---|---|
| `dropwizard.version` | 3.0.16 | 5.0.2 |
| Jetty | 10.0.26 (transitive) | 12.1.12 |
| `maven.compiler.release` | 11 | 17 |
| Dockerfile JDK | Temurin 11 | Temurin 21 |
| CI `java-version` | `[11, 17, 21, 25]` | `[17, 21, 25]` |

- `javax.ws.rs`, `javax.servlet` and `javax.inject` → `jakarta.*` across 7 files.
- `org.eclipse.jetty.servlets.CrossOriginFilter` → `org.eclipse.jetty.ee10.servlets.CrossOriginFilter`. Dropwizard 5 pulls `jetty-ee10-servlet` but **not** `jetty-ee10-servlets`, so that one is declared explicitly.
- `jackson-jaxrs-xml-provider` → `jackson-jakarta-rs-xml-provider`.
- `jetty-bom` and `jetty-ee10-bom` imported at **12.1.12**, not left at the 12.1.9 Dropwizard 5.0.2 ships, because `CVE-2026-10050` is fixed in 12.1.10.

Two notes on things that are easy to get wrong here:

**The `jackson-bom` import has to be in the root POM.** Dropwizard's own BOM manages Jackson for itself, and a version a dependency manages for itself loses to a root `<dependencyManagement>` entry but beats a plain `<version>` — so setting `fasterxml.version` alone does not move the transitive `jackson-databind`.

**`jdk.unsupported` is now in the jlink module set** in both Dockerfiles. It carries `sun.misc.Unsafe`, which the Swagger classpath scanner reaches for on the *first* `/openapi.json` request. Without it that request answers 500 and every request after it answers 200 — so each container restart serves exactly one bad response, and a warmed healthcheck never sees it.

## The Swagger bundle had to be replaced

`com.smoketurner:dropwizard-swagger` stops at **4.0.5-1** (released 2024-01-01) with no `jakarta` and no Dropwizard 5 build. It is the one dependency here with no drop-in successor.

- The **spec** now comes from registering `io.swagger.core.v3:swagger-jaxrs2-jakarta`'s `OpenApiResource` directly. `/openapi.json` and `/openapi.yaml` are unchanged.
- The **UI** is a new `SwaggerUiResource` + `SwaggerUiView` + `swagger.mustache`, following the existing `HomePageResource` / `RestClientView` pattern, over the `org.webjars:swagger-ui` webjar mounted at `/swagger-ui`. `/swagger` still serves the same page.

A mustache view rather than a static asset, because `.gitignore` excludes `*.html` — an `index.html` asset builds locally and then goes missing from a fresh clone.

The webjar path contains its version, so `SWAGGER_UI_WEBJAR_PATH` in `VeraPdfRestApplication` has to be kept in step with the `swagger.ui.version` property. Happy to swap in `webjars-locator` if you would rather not have the two in sync by hand.

## Verification

Both `integration` at `c2f7713` and this branch were built into the runtime image the `Dockerfile` produces and compared endpoint by endpoint.

```
                          baseline (c2f7713)    this branch
registered profiles       15                    15
OpenAPI paths             13                    13
OpenAPI schemas           20                    20
GET /                     200                   200
GET /swagger              200                   200
GET /openapi.json         200                   200  (first request, cold)
GET /openapi.yaml         200                   200
ERROR lines in log        0                     0
```

All 16 profile ids return byte-identical validation output:

```
1a    PDF/A-1a  passed=124  failed=11      4     PDF/A-4          passed=107   failed=4
1b    PDF/A-1b  passed=120  failed=9       4e    PDF/A-4e         passed=107   failed=4
2a    PDF/A-2a  passed=150  failed=3       4f    PDF/A-4f         passed=106   failed=5
2b    PDF/A-2b  passed=143  failed=1       ua1   PDF/UA-1         passed=100   failed=6
2u    PDF/A-2u  passed=145  failed=1       ua2   PDF/UA-2+Tagged  passed=1721  failed=6
3a    PDF/A-3a  passed=152  failed=3       wt1a  WTPDF 1.0 Acc.   passed=1717  failed=6
3b    PDF/A-3b  passed=145  failed=1       wt1r  WTPDF 1.0 Reuse  passed=1705  failed=5
3u    PDF/A-3u  passed=147  failed=1       wcag2 (same parse exception on both)
```

XML responses (`Accept: application/xml`) are unchanged.

## Two OpenAPI generation differences

Both come from swagger-core, not from a deliberate change here. Flagging them rather than burying them:

1. **Enum values are now the serialized forms the API accepts** — `"1b"`, `"ua1"`, `"ISO 14289-1:2014"` — where the old spec emitted Java constant names — `"PDFA_1_B"`, `"PDFUA_1"`, `"ISO_14289_1"`. Same four enum blocks, same members, same counts. This looks like a fix: the old spec documented identifiers a caller could not actually send.
2. **Six `xml` metadata blocks are gone.** `swagger-core-jakarta` reads `jakarta.xml.bind` annotations and the model classes still carry `javax.xml.bind` ones. Documentation only — the XML responses themselves are byte-for-byte unchanged. It resolves on its own when the model libraries migrate.

Tell me if either of those is a blocker and I will dig further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive Swagger UI API documentation at `/swagger`.
  - Added OpenAPI specifications in JSON and YAML formats.
  - Updated API documentation tooling for improved Jakarta EE and Jetty compatibility.

- **Improvements**
  - Upgraded the application runtime and build environment to Java 21.
  - Updated REST components to Jakarta namespaces.
  - Updated tested Java versions to 17, 21, and 25.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->